### PR TITLE
Renaming tool from reforge to specforge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Instructions
 
-This file provides guidance to Claude Code when working on the reforge
+This file provides guidance to Claude Code when working on the specforge
 codebase.
 
 ## Project overview
 
-This is the **Reforge** CLI project that allows developers to configure their
+This is the **Specforge** CLI project that allows developers to configure their
 source control for AI-driven developments through Github Copilot or Claude
 Code.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,20 +441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "reforge"
-version = "0.1.0"
-dependencies = [
- "assert_cmd",
- "chrono",
- "clap",
- "dialoguer",
- "predicates",
- "serde",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +537,20 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "specforge"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "dialoguer",
+ "predicates",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "reforge"
+name = "specforge"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Reforge
+# Specforge
 
-Welcome to Reforge, a tool to help you get started with spec-driven development
-using AI. This repository contains the sources for the Reforge tool. You can use
-this tool to quickly set up your project for spec-driven development using
-an AI coding agent.
+Welcome to Specforge, a tool to help you get started with spec-driven
+development using AI. This repository contains the sources for the Specforge
+tool. You can use this tool to quickly set up your project for spec-driven
+development using an AI coding agent.
 
 ------
 
@@ -14,13 +14,13 @@ and should only be used if you love experimenting with spec-driven development.
 
 ## Getting started
 
-Download the latest release of the Reforge CLI, and make sure it is in your
+Download the latest release of the Specforge CLI, and make sure it is in your
 `PATH` environment variable.
 
 Then, run the following command to initialize your project:
 
 ```shell
-reforge init
+specforge init
 ```
 
 The tool will ask for the agent you're using (Claude Code or Github Copilot)
@@ -79,7 +79,7 @@ After that, we'll evaluate the results and add agent support as needed.
 
 - **What operating systems are supported?**  
   We support Windows, Mac, and Linux. The prompt templates themselves are
-  saved as markdown files in your project, and Reforge isn't involved in
+  saved as markdown files in your project, and Specforge isn't involved in
   using them.
 
 - **Can I customize the prompt templates?**  

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use dialoguer::{Select, theme::ColorfulTheme};
 use std::path::PathBuf;
 
-/// Initialize a new Reforge project with agent configuration
+/// Initialize a new Specforge project with agent configuration
 #[derive(Args)]
 pub struct InitCommand {
     /// The AI agent to configure for this project
@@ -106,7 +106,7 @@ fn validate_output_directory(s: &str) -> Result<PathBuf> {
 impl InitCommand {
     /// Execute the init command
     pub fn execute(&self) -> Result<()> {
-        println!("ℹ️  Initializing Reforge project...");
+        println!("ℹ️  Initializing Specforge project...");
 
         // Validate command arguments with context
         self.validate()
@@ -153,7 +153,7 @@ impl InitCommand {
             e.add_context(
                 "configuration file writing",
                 &format!(
-                    "Writing .reforge.json to {}",
+                    "Writing .specforge.json to {}",
                     self.output_directory.display()
                 ),
             )
@@ -161,7 +161,7 @@ impl InitCommand {
 
         // Display success message
         println!(
-            "✅ Successfully created Reforge configuration at: {}",
+            "✅ Successfully created Specforge configuration at: {}",
             config_path.display()
         );
 
@@ -251,7 +251,7 @@ impl InitCommand {
         config.add_package(default_package)?;
 
         // Set additional metadata
-        config.set_metadata("initialized_by", "reforge-cli");
+        config.set_metadata("initialized_by", "specforge-cli");
         config.set_metadata("version", env!("CARGO_PKG_VERSION"));
 
         // Validate the configuration
@@ -270,8 +270,8 @@ impl InitCommand {
         let package_version = env!("CARGO_PKG_VERSION");
 
         match agent {
-            Agent::Copilot => Package::new("reforge-copilot-templates", package_version),
-            Agent::Claude => Package::new("reforge-claude-templates", package_version),
+            Agent::Copilot => Package::new("specforge-copilot-templates", package_version),
+            Agent::Claude => Package::new("specforge-claude-templates", package_version),
         }
     }
 
@@ -285,12 +285,12 @@ impl InitCommand {
 
         match agent {
             Agent::Copilot => vec![
-                Package::new("reforge-copilot-templates", package_version),
-                // Future: Additional packages like "reforge-copilot-advanced-templates"
+                Package::new("specforge-copilot-templates", package_version),
+                // Future: Additional packages like "specforge-copilot-advanced-templates"
             ],
             Agent::Claude => vec![
-                Package::new("reforge-claude-templates", package_version),
-                // Future: Additional packages like "reforge-claude-advanced-templates"
+                Package::new("specforge-claude-templates", package_version),
+                // Future: Additional packages like "specforge-claude-advanced-templates"
             ],
         }
     }
@@ -299,7 +299,7 @@ impl InitCommand {
     fn display_next_steps(&self, agent: &Agent) {
         println!();
         println!("🎉 Next steps:");
-        println!("   1. Review the generated .reforge.json configuration");
+        println!("   1. Review the generated .specforge.json configuration");
         println!("   2. Customize the configuration as needed");
         println!("   3. Start using your AI agent with the configured templates");
 
@@ -485,7 +485,7 @@ mod tests {
         assert_eq!(config.agent, Agent::Claude);
         assert_eq!(config.project_name(), Some("test-project"));
         assert_eq!(config.packages.len(), 1);
-        assert_eq!(config.packages[0].id, "reforge-claude-templates");
+        assert_eq!(config.packages[0].id, "specforge-claude-templates");
         assert!(config.get_metadata("initialized_by").is_some());
         assert!(config.get_metadata("version").is_some());
     }
@@ -502,11 +502,11 @@ mod tests {
         let expected_version = env!("CARGO_PKG_VERSION");
 
         let copilot_package = cmd.create_default_package(&Agent::Copilot);
-        assert_eq!(copilot_package.id, "reforge-copilot-templates");
+        assert_eq!(copilot_package.id, "specforge-copilot-templates");
         assert_eq!(copilot_package.version, expected_version);
 
         let claude_package = cmd.create_default_package(&Agent::Claude);
-        assert_eq!(claude_package.id, "reforge-claude-templates");
+        assert_eq!(claude_package.id, "specforge-claude-templates");
         assert_eq!(claude_package.version, expected_version);
     }
 
@@ -598,7 +598,7 @@ mod tests {
 
         // Test acceptance criteria:
         // - Packages array is created with appropriate template package entries
-        assert_eq!(copilot_package.id, "reforge-copilot-templates");
+        assert_eq!(copilot_package.id, "specforge-copilot-templates");
 
         // - Package IDs are meaningful and consistent
         assert!(copilot_package.id.contains("copilot"));
@@ -628,7 +628,7 @@ mod tests {
         let claude_package = &claude_config.packages[0];
 
         // - Different agents can have different default packages if needed
-        assert_eq!(claude_package.id, "reforge-claude-templates");
+        assert_eq!(claude_package.id, "specforge-claude-templates");
         assert_ne!(claude_package.id, copilot_package.id);
 
         // - Version information is consistent across agents
@@ -642,7 +642,7 @@ mod tests {
         assert!(json_string.contains("\"packages\""));
         assert!(json_string.contains("\"id\""));
         assert!(json_string.contains("\"version\""));
-        assert!(json_string.contains("reforge-copilot-templates"));
+        assert!(json_string.contains("specforge-copilot-templates"));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,19 +48,19 @@ impl fmt::Display for ConfigError {
                     err, suggestion, err.kind())
             }
             ConfigError::JsonError(err) => {
-                write!(f, "Failed to parse JSON configuration: {}\n\nEnsure the .reforge.json file contains valid JSON syntax.\nTip: You can validate JSON online or use 'cat .reforge.json | jq .' to check formatting.\n\nDebug info: Line {}, Column {}",
+                write!(f, "Failed to parse JSON configuration: {}\n\nEnsure the .specforge.json file contains valid JSON syntax.\nTip: You can validate JSON online or use 'cat .specforge.json | jq .' to check formatting.\n\nDebug info: Line {}, Column {}",
                     err,
                     err.line(),
                     err.column())
             }
             ConfigError::ValidationError(msg) => {
-                write!(f, "Configuration validation failed: {}\n\nPlease check your configuration file format and ensure all required fields are present.\nFor reference, run 'reforge init' to see the expected format.", msg)
+                write!(f, "Configuration validation failed: {}\n\nPlease check your configuration file format and ensure all required fields are present.\nFor reference, run 'specforge init' to see the expected format.", msg)
             }
             ConfigError::InvalidAgent(agent) => {
-                write!(f, "Invalid agent '{}' specified.\n\nSupported agents are:\n  • 'copilot' - GitHub Copilot integration\n  • 'claude' - Anthropic Claude integration\n\nExamples:\n  reforge init --agent copilot\n  reforge init --agent claude", agent)
+                write!(f, "Invalid agent '{}' specified.\n\nSupported agents are:\n  • 'copilot' - GitHub Copilot integration\n  • 'claude' - Anthropic Claude integration\n\nExamples:\n  specforge init --agent copilot\n  specforge init --agent claude", agent)
             }
             ConfigError::FileExists(path) => {
-                write!(f, "Configuration file already exists at: {}\n\nOptions:\n  • Use 'reforge init --force' to overwrite\n  • Choose a different directory with '--output-directory <path>'\n  • Remove the existing file manually: rm {}",
+                write!(f, "Configuration file already exists at: {}\n\nOptions:\n  • Use 'specforge init --force' to overwrite\n  • Choose a different directory with '--output-directory <path>'\n  • Remove the existing file manually: rm {}",
                     path.display(), path.display())
             }
             ConfigError::PermissionDenied(path) => {
@@ -77,10 +77,10 @@ impl fmt::Display for ConfigError {
                     path.display(), path.display(), path.display(), path.display())
             }
             ConfigError::MissingRequiredField(field) => {
-                write!(f, "Required field '{}' is missing from configuration.\n\nQuick fix:\n  1. Backup current config: cp .reforge.json .reforge.json.backup\n  2. Recreate config: reforge init\n  3. Merge custom settings from backup if needed", field)
+                write!(f, "Required field '{}' is missing from configuration.\n\nQuick fix:\n  1. Backup current config: cp .specforge.json .specforge.json.backup\n  2. Recreate config: specforge init\n  3. Merge custom settings from backup if needed", field)
             }
             ConfigError::InvalidPackage(msg) => {
-                write!(f, "Invalid package configuration: {}\n\nPackage requirements:\n  • ID must be non-empty and contain no whitespace\n  • Version must follow semantic versioning (e.g., '1.0.0')\n  • URL (if provided) must start with 'http://' or 'https://'\n\nCheck the packages array in your .reforge.json file.", msg)
+                write!(f, "Invalid package configuration: {}\n\nPackage requirements:\n  • ID must be non-empty and contain no whitespace\n  • Version must follow semantic versioning (e.g., '1.0.0')\n  • URL (if provided) must start with 'http://' or 'https://'\n\nCheck the packages array in your .specforge.json file.", msg)
             }
             ConfigError::UserCancelled(msg) => {
                 write!(f, "Operation cancelled: {}\n\nYou can restart the operation at any time.", msg)
@@ -362,10 +362,10 @@ mod tests {
 
     #[test]
     fn test_file_exists_error() {
-        let error = ConfigError::file_exists("/test/.reforge.json");
+        let error = ConfigError::file_exists("/test/.specforge.json");
         let msg = error.to_string();
         assert!(msg.contains("Configuration file already exists"));
-        assert!(msg.contains("/test/.reforge.json"));
+        assert!(msg.contains("/test/.specforge.json"));
         assert!(msg.contains("--force"));
     }
 
@@ -374,7 +374,7 @@ mod tests {
         let error = ConfigError::missing_required_field("agent");
         let msg = error.to_string();
         assert!(msg.contains("Required field 'agent'"));
-        assert!(msg.contains("reforge init"));
+        assert!(msg.contains("specforge init"));
     }
 
     #[test]

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 /// Configuration file name constant
-pub const CONFIG_FILE_NAME: &str = ".reforge.json";
+pub const CONFIG_FILE_NAME: &str = ".specforge.json";
 
 /// File information for display in confirmation prompts
 #[derive(Debug, Clone)]
@@ -89,7 +89,7 @@ impl FileOps {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);
-        let temp_file_name = format!(".reforge_temp_test_{}", unique_suffix);
+        let temp_file_name = format!(".specforge_temp_test_{}", unique_suffix);
         let temp_file_path = dir_path.join(temp_file_name);
 
         match fs::write(&temp_file_path, "") {
@@ -165,7 +165,7 @@ impl FileOps {
         Ok(config)
     }
 
-    /// Write a ProjectConfig to the standard .reforge.json file in a directory
+    /// Write a ProjectConfig to the standard .specforge.json file in a directory
     pub fn write_config_to_directory<P: AsRef<Path>>(
         config: &ProjectConfig,
         dir_path: P,
@@ -177,7 +177,7 @@ impl FileOps {
         Ok(config_path)
     }
 
-    /// Read a ProjectConfig from the standard .reforge.json file in a directory
+    /// Read a ProjectConfig from the standard .specforge.json file in a directory
     pub fn read_config_from_directory<P: AsRef<Path>>(dir_path: P) -> Result<ProjectConfig> {
         let dir_path = dir_path.as_ref();
         let config_path = dir_path.join(CONFIG_FILE_NAME);
@@ -185,7 +185,7 @@ impl FileOps {
         Self::read_config(config_path)
     }
 
-    /// Check if a .reforge.json file exists in a directory
+    /// Check if a .specforge.json file exists in a directory
     pub fn config_exists_in_directory<P: AsRef<Path>>(dir_path: P) -> bool {
         let config_path = dir_path.as_ref().join(CONFIG_FILE_NAME);
         config_path.exists()
@@ -672,7 +672,7 @@ mod tests {
         assert!(new_dir.exists()); // Should create directory
 
         // Our specific behavior: temp test file should be cleaned up
-        let temp_test_file = new_dir.join(".reforge_temp_test");
+        let temp_test_file = new_dir.join(".specforge_temp_test");
         assert!(!temp_test_file.exists());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 use clap::{Parser, Subcommand};
-use reforge::ConfigError;
-use reforge::cli::InitCommand;
+use specforge::ConfigError;
+use specforge::cli::InitCommand;
 use std::process;
 
-/// Reforge CLI - Configure source control for AI-driven development
+/// Specforge CLI - Configure source control for AI-driven development
 #[derive(Parser)]
 #[command(
-    name = "reforge",
+    name = "specforge",
     version,
     about = "Configure source control for AI-driven development through GitHub Copilot or Claude Code",
-    long_about = "Reforge allows developers to configure their source control for AI-driven development \
+    long_about = "Specforge allows developers to configure their source control for AI-driven development \
                  by quickly deploying custom prompt templates for coding agents. Follow a specification-driven \
                  workflow where you handle specifications and review while the AI handles the coding.",
-    author = "Reforge Contributors"
+    author = "Specforge Contributors"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -22,7 +22,7 @@ pub struct Cli {
 /// Available commands
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Initialize a new Reforge project with agent configuration
+    /// Initialize a new Specforge project with agent configuration
     Init(InitCommand),
 }
 
@@ -30,7 +30,7 @@ pub enum Commands {
 /// Handle CLI errors and exit with appropriate codes
 fn handle_error(error: ConfigError) -> ! {
     // Log error details securely for debugging (without sensitive info)
-    if std::env::var("REFORGE_DEBUG").is_ok() {
+    if std::env::var("SPECFORGE_DEBUG").is_ok() {
         error.log_securely();
     }
 
@@ -70,7 +70,7 @@ fn main() {
 mod tests {
     use super::*;
     use clap::CommandFactory;
-    use reforge::cli::AgentType;
+    use specforge::cli::AgentType;
 
     #[test]
     fn test_cli_structure() {
@@ -80,21 +80,21 @@ mod tests {
 
     #[test]
     fn test_agent_type_conversion() {
-        // Test conversion from AgentType to reforge::config::Agent
-        let copilot_agent = reforge::config::Agent::from(AgentType::Copilot);
-        assert_eq!(copilot_agent, reforge::config::Agent::Copilot);
+        // Test conversion from AgentType to specforge::config::Agent
+        let copilot_agent = specforge::config::Agent::from(AgentType::Copilot);
+        assert_eq!(copilot_agent, specforge::config::Agent::Copilot);
         
-        let claude_agent = reforge::config::Agent::from(AgentType::Claude);
-        assert_eq!(claude_agent, reforge::config::Agent::Claude);
+        let claude_agent = specforge::config::Agent::from(AgentType::Claude);
+        assert_eq!(claude_agent, specforge::config::Agent::Claude);
     }
 
     #[test]
     fn test_reverse_agent_conversion() {
-        // Test conversion from reforge::config::Agent to AgentType
-        let copilot_type = AgentType::from(reforge::config::Agent::Copilot);
+        // Test conversion from specforge::config::Agent to AgentType
+        let copilot_type = AgentType::from(specforge::config::Agent::Copilot);
         assert!(matches!(copilot_type, AgentType::Copilot));
         
-        let claude_type = AgentType::from(reforge::config::Agent::Claude);
+        let claude_type = AgentType::from(specforge::config::Agent::Claude);
         assert!(matches!(claude_type, AgentType::Claude));
     }
 

--- a/tests/integration_init.rs
+++ b/tests/integration_init.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use tempfile::TempDir;
 
 /// Helper function to create a command for testing
-fn reforge_cmd() -> Command {
-    Command::cargo_bin("reforge").unwrap()
+fn specforge_cmd() -> Command {
+    Command::cargo_bin("specforge").unwrap()
 }
 
 /// Helper function to validate JSON file content
@@ -48,7 +48,7 @@ fn validate_json_content(file_path: &Path, expected_agent: &str) {
 fn test_init_with_copilot_agent() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -56,12 +56,12 @@ fn test_init_with_copilot_agent() {
         .arg(temp_dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Initializing Reforge project"))
+        .stdout(predicate::str::contains("Initializing Specforge project"))
         .stdout(predicate::str::contains("Selected agent: copilot"))
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Validate file creation and content
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     validate_json_content(&config_path, "copilot");
 }
 
@@ -69,7 +69,7 @@ fn test_init_with_copilot_agent() {
 fn test_init_with_claude_agent() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -77,12 +77,12 @@ fn test_init_with_claude_agent() {
         .arg(temp_dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Initializing Reforge project"))
+        .stdout(predicate::str::contains("Initializing Specforge project"))
         .stdout(predicate::str::contains("Selected agent: claude"))
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Validate file creation and content
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     validate_json_content(&config_path, "claude");
 }
 
@@ -90,7 +90,7 @@ fn test_init_with_claude_agent() {
 fn test_init_with_project_name() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -100,10 +100,10 @@ fn test_init_with_project_name() {
         .arg(temp_dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Validate project name in JSON
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     let content = fs::read_to_string(&config_path).unwrap();
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
 
@@ -119,27 +119,27 @@ fn test_init_to_current_directory() {
     let temp_dir = TempDir::new().unwrap();
 
     // Change to temp directory and run init without output-directory
-    reforge_cmd()
+    specforge_cmd()
         .current_dir(temp_dir.path())
         .arg("init")
         .arg("--agent")
         .arg("claude")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Validate file creation in current directory
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     validate_json_content(&config_path, "claude");
 }
 
 #[test]
 fn test_init_with_force_overwrite() {
     let temp_dir = TempDir::new().unwrap();
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
 
     // Create initial config
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -152,7 +152,7 @@ fn test_init_with_force_overwrite() {
     validate_json_content(&config_path, "copilot");
 
     // Overwrite with force flag
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -161,7 +161,7 @@ fn test_init_with_force_overwrite() {
         .arg("--force")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Verify config was overwritten
     validate_json_content(&config_path, "claude");
@@ -171,7 +171,7 @@ fn test_init_with_force_overwrite() {
 fn test_init_invalid_agent() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("invalid-agent")
@@ -183,13 +183,13 @@ fn test_init_invalid_agent() {
         .stderr(predicate::str::contains("invalid value"));
 
     // Verify no config file was created
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     assert!(!config_path.exists(), "Config file should not be created on error");
 }
 
 #[test]
 fn test_init_nonexistent_directory() {
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -207,7 +207,7 @@ fn test_init_missing_agent_flag() {
 
     // This should fail because agent is required
     // The actual behavior depends on the implementation
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--output-directory")
         .arg(temp_dir.path())
@@ -219,12 +219,12 @@ fn test_init_missing_agent_flag() {
 
 #[test]
 fn test_init_help_message() {
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Initialize a new Reforge project"))
+        .stdout(predicate::str::contains("Initialize a new Specforge project"))
         .stdout(predicate::str::contains("--agent"))
         .stdout(predicate::str::contains("--output-directory"))
         .stdout(predicate::str::contains("--project-name"))
@@ -236,7 +236,7 @@ fn test_init_creates_directory_if_needed() {
     let temp_dir = TempDir::new().unwrap();
     let nested_dir = temp_dir.path().join("new").join("nested").join("directory");
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -245,13 +245,13 @@ fn test_init_creates_directory_if_needed() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Creating output directory"))
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Verify directory and file were created
     assert!(nested_dir.exists(), "Nested directory should be created");
     assert!(nested_dir.is_dir(), "Path should be a directory");
 
-    let config_path = nested_dir.join(".reforge.json");
+    let config_path = nested_dir.join(".specforge.json");
     validate_json_content(&config_path, "copilot");
 }
 
@@ -259,7 +259,7 @@ fn test_init_creates_directory_if_needed() {
 fn test_json_schema_compliance() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -270,7 +270,7 @@ fn test_json_schema_compliance() {
         .assert()
         .success();
 
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     let content = fs::read_to_string(&config_path).unwrap();
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
 
@@ -308,7 +308,7 @@ fn test_json_schema_compliance() {
 fn test_init_preserves_json_formatting() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -317,7 +317,7 @@ fn test_init_preserves_json_formatting() {
         .assert()
         .success();
 
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     let content = fs::read_to_string(&config_path).unwrap();
 
     // Verify JSON is pretty-printed
@@ -333,7 +333,7 @@ fn test_init_preserves_json_formatting() {
 fn test_init_version_consistency() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -342,7 +342,7 @@ fn test_init_version_consistency() {
         .assert()
         .success();
 
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     let content = fs::read_to_string(&config_path).unwrap();
     let json: serde_json::Value = serde_json::from_str(&content).unwrap();
 
@@ -374,7 +374,7 @@ fn test_init_package_id_format() {
     let temp_dir = TempDir::new().unwrap();
 
     // Test Copilot package ID
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -383,7 +383,7 @@ fn test_init_package_id_format() {
         .assert()
         .success();
 
-    let copilot_config = temp_dir.path().join("copilot").join(".reforge.json");
+    let copilot_config = temp_dir.path().join("copilot").join(".specforge.json");
     let copilot_content = fs::read_to_string(&copilot_config).unwrap();
     let copilot_json: serde_json::Value = serde_json::from_str(&copilot_content).unwrap();
 
@@ -392,10 +392,10 @@ fn test_init_package_id_format() {
         .get("id").unwrap()
         .as_str().unwrap();
 
-    assert_eq!(copilot_package_id, "reforge-copilot-templates");
+    assert_eq!(copilot_package_id, "specforge-copilot-templates");
 
     // Test Claude package ID
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -404,7 +404,7 @@ fn test_init_package_id_format() {
         .assert()
         .success();
 
-    let claude_config = temp_dir.path().join("claude").join(".reforge.json");
+    let claude_config = temp_dir.path().join("claude").join(".specforge.json");
     let claude_content = fs::read_to_string(&claude_config).unwrap();
     let claude_json: serde_json::Value = serde_json::from_str(&claude_content).unwrap();
 
@@ -413,7 +413,7 @@ fn test_init_package_id_format() {
         .get("id").unwrap()
         .as_str().unwrap();
 
-    assert_eq!(claude_package_id, "reforge-claude-templates");
+    assert_eq!(claude_package_id, "specforge-claude-templates");
 
     // Package IDs should be different for different agents
     assert_ne!(copilot_package_id, claude_package_id);
@@ -423,7 +423,7 @@ fn test_init_package_id_format() {
 fn test_init_error_messages_quality() {
     // Test with permission denied scenario (if possible to simulate)
     // Note: This test might be platform-specific and may not work in all environments
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("copilot")
@@ -439,7 +439,7 @@ fn test_init_error_messages_quality() {
 fn test_init_with_all_flags() {
     let temp_dir = TempDir::new().unwrap();
 
-    reforge_cmd()
+    specforge_cmd()
         .arg("init")
         .arg("--agent")
         .arg("claude")
@@ -450,12 +450,12 @@ fn test_init_with_all_flags() {
         .arg("--force") // Should work even without existing file
         .assert()
         .success()
-        .stdout(predicate::str::contains("Initializing Reforge project"))
+        .stdout(predicate::str::contains("Initializing Specforge project"))
         .stdout(predicate::str::contains("Selected agent: claude"))
-        .stdout(predicate::str::contains("Successfully created Reforge configuration"));
+        .stdout(predicate::str::contains("Successfully created Specforge configuration"));
 
     // Validate all aspects of the generated config
-    let config_path = temp_dir.path().join(".reforge.json");
+    let config_path = temp_dir.path().join(".specforge.json");
     validate_json_content(&config_path, "claude");
 
     // Validate project name


### PR DESCRIPTION
This pull request renames the entire project from "Reforge" to "Specforge" to reflect the new branding. The change is comprehensive, affecting documentation, user-facing messages, configuration files, constants, code comments, error messages, and test cases throughout the codebase.

The most important changes are:

**Project and CLI Renaming:**
* The project name is changed from "reforge" to "specforge" in `Cargo.toml`, all documentation files (`README.md`, `CLAUDE.md`), and throughout code comments and user-facing CLI messages. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L2-R2) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R6) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R23) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R82) [[5]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L8-R8) [[6]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L109-R109) [[7]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L156-R164) [[8]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2-R15) [[9]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL25-R33)

**Configuration and File Naming:**
* The configuration file `.reforge.json` is renamed to `.specforge.json` everywhere, including constants, file operations, documentation, and error messages. [[1]](diffhunk://#diff-292a13cf1a66128139fc9675d2ccac0c15975b1fb654088f0bb6f83d76aa6a06L10-R10) [[2]](diffhunk://#diff-292a13cf1a66128139fc9675d2ccac0c15975b1fb654088f0bb6f83d76aa6a06L168-R168) [[3]](diffhunk://#diff-292a13cf1a66128139fc9675d2ccac0c15975b1fb654088f0bb6f83d76aa6a06L180-R188) [[4]](diffhunk://#diff-292a13cf1a66128139fc9675d2ccac0c15975b1fb654088f0bb6f83d76aa6a06L92-R92) [[5]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL51-R63) [[6]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL80-R83)

**Package and Metadata Updates:**
* All references to default template package IDs and metadata are updated from `reforge-*` to `specforge-*` (e.g., `specforge-copilot-templates`). [[1]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L254-R254) [[2]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L273-R274) [[3]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L288-R293) [[4]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L488-R488) [[5]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L505-R509) [[6]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L601-R601) [[7]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L631-R631) [[8]](diffhunk://#diff-974bd3a66c20e01cc77f4fe08084db8ad32ef80292be90c5e69e6a6a58111b33L645-R645)

**Environment Variables and Debugging:**
* The environment variable for debugging is changed from `REFORGE_DEBUG` to `SPECFORGE_DEBUG`.

**Test and Example Updates:**
* All tests and example commands now use the new "specforge" naming and configuration file references. [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL365-R368) [[2]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL377-R377) [[3]](diffhunk://#diff-292a13cf1a66128139fc9675d2ccac0c15975b1fb654088f0bb6f83d76aa6a06L675-R675)

This update ensures a consistent transition to the new "Specforge" branding across all aspects of the project.